### PR TITLE
Correct docker-compose & missing values in .env.example

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,6 @@ POSTGRES_URL=jdbc:postgresql://localhost:5432/database
 POSTGRES_DB=database
 POSTGRES_USER=username
 POSTGRES_PASSWORD=password
+
+JWT_SECRET=JX9mVq7WbP3dT8zLrK6YfN2C4sAHGZQo     # Cadena de al menos 32 caracteres
+JWT_EXPIRATION=604800000                        # Tiempo en milisegundos

--- a/backend/Docker-compose.yml
+++ b/backend/Docker-compose.yml
@@ -1,27 +1,34 @@
-version: "3.8"
 services:
-  db:
+  postgres:
     image: postgres:15
     restart: always
+    container_name: postgres_container
     environment:
-      POSTGRES_DB: fuitalentdb
-      POSTGRES_USER: admin
-      POSTGRES_PASSWORD: admin123
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+    env_file:
+      - .env
 
   backend:
     build: .
+    container_name: backend_container
     depends_on:
-      - db
+      - postgres
     ports:
       - "8080:8080"
     environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/fuitalentdb
-      SPRING_DATASOURCE_USERNAME: admin
-      SPRING_DATASOURCE_PASSWORD: admin123
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/${POSTGRES_DB}
+      SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER}
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_EXPIRATION: ${JWT_EXPIRATION}
+    env_file:
+      - .env
 
 volumes:
   postgres-data:


### PR DESCRIPTION
- Corrección en la configuración de `docker-compose.yml` para asegurar la conexión adecuada con PostgreSQL dentro de la red interna de Docker y tomar valores de las variables de entorno.  
- Se agregaron valores faltantes en `.env.example` para mejorar la configuración y facilitar la implementación en diferentes entornos.